### PR TITLE
[CDMS-126-129-131] Implement bankwizard client, API documentation and data transfer

### DIFF
--- a/__mocks__/soap.js
+++ b/__mocks__/soap.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const soap = jest.createMockFromModule('soap');
+
+// eslint-disable-next-line no-unused-vars
+function createClient(url, callback, endpoint) {
+    callback(null, {
+        BankWizard_v1_1_Service: {
+            BankWizard_v1_1_0_Port: {
+                Verify: (msg, cb) => {
+                    cb(null, msg);
+                },
+            },
+        },
+    });
+}
+
+soap.createClient = createClient;
+
+module.exports = soap;

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const pino = require('pino-http');
 const OpenApiValidator = require('express-openapi-validator');
 const errorHandler = require('./middleware/error-handler');
 const docsRouter = require('./docs/routes');
+const bankWizardRouter = require('./bankwizard/routes');
 
 process.env.DCS_LOG_LEVEL = 'debug';
 
@@ -66,7 +67,7 @@ app.use(
 // logging
 app.use(logger);
 // https://expressjs.com/en/api.html#express.json
-app.use(express.json({type: 'application/vnd.api+json'}));
+app.use(express.json({type: 'application/json'}));
 // https://expressjs.com/en/api.html#express.urlencoded
 app.use(express.urlencoded({extended: true}));
 app.use(cookieParser());
@@ -75,9 +76,20 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/docs', docsRouter);
 
+app.use(
+    '/v2/bankwizard',
+    OpenApiValidator.middleware({
+        apiSpec: './openapi/openapi.json',
+        validateRequests: true,
+        validateResponses: false,
+        validateSecurity: false,
+    }),
+    bankWizardRouter,
+);
+
 app.use((req, res, next) => {
     // Default to JSON:API content type for all subsequent responses
-    res.type('application/vnd.api+json');
+    res.type('application/json');
     // https://stackoverflow.com/a/22339262/2952356
     // `process.env.npm_package_version` only works if you use npm start to run the app.
     res.set('Application-Version', process.env.npm_package_version);

--- a/bankwizard/bankwizard-service.js
+++ b/bankwizard/bankwizard-service.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function createBankWizardService() {
+    function bankWizardPersonalRequest(body) {
+        console.log(body);
+        return true;
+    }
+
+    function bankWizardCompanyRequest(body) {
+        console.log(body);
+        return false;
+    }
+
+    return Object.freeze({
+        bankWizardPersonalRequest,
+        bankWizardCompanyRequest,
+    });
+}
+
+module.exports = createBankWizardService;

--- a/bankwizard/bankwizard-service.js
+++ b/bankwizard/bankwizard-service.js
@@ -1,20 +1,76 @@
 'use strict';
 
-function createBankWizardService() {
-    function bankWizardPersonalRequest(body) {
-        console.log(body);
-        return true;
-    }
+const bankwizardClient = require('../services/soap/bankwizard-client');
 
-    function bankWizardCompanyRequest(body) {
-        console.log(body);
-        return false;
-    }
+function checkAccountConditions(verifyResult) {
+    const {conditions} = verifyResult;
+    const {accountVerificationStatus} = verifyResult.accountInformation;
 
-    return Object.freeze({
-        bankWizardPersonalRequest,
-        bankWizardCompanyRequest,
-    });
+    if (conditions) {
+        if (conditions.length < 1) {
+            if (accountVerificationStatus === '') {
+                // TODO error handling
+            }
+            return true;
+        }
+
+        conditions.array.forEach((condition) => {
+            // eslint-disable-next-line no-unused-vars
+            const {code, severity} = condition;
+            if (severity === 'error') {
+                // TODO error condition handling
+            } else if (severity === 'warning') {
+                // TODO warning condition handling
+            }
+        });
+    }
+    return true;
 }
 
-module.exports = createBankWizardService;
+// eslint-disable-next-line no-unused-vars
+function getScores(responseBody, res, verifyResult, next) {
+    if (verifyResult.personalInformation) {
+        if (verifyResult.personalInformation.personalDetailsScore) {
+            responseBody.personalScore = Number(
+                verifyResult.personalInformation.personalDetailsScore,
+            );
+        }
+        if (verifyResult.personalInformation.addressScore) {
+            responseBody.addressScore = Number(verifyResult.personalInformation.addressScore);
+        }
+    } else if (verifyResult.companyInformation) {
+        if (verifyResult.companyInformation.companyNameScore) {
+            responseBody.companyScore = Number(verifyResult.companyInformation.companyNameScore);
+        }
+        if (verifyResult.companyInformation.addressScore) {
+            responseBody.addressScore = Number(verifyResult.companyInformation.addressScore);
+        }
+    }
+
+    res.status(200).json(responseBody);
+}
+
+function verifyRequestCallback(result, res, client, next) {
+    const validateScore = checkAccountConditions(result);
+    const responseBody = {
+        validateScore,
+    };
+    if (validateScore) {
+        bankwizardClient.getBranchData(client, result, responseBody, getScores, res, next);
+    } else {
+        getScores(responseBody, res, result, next);
+    }
+}
+
+function bankWizardPersonalRequest(req, res, next) {
+    bankwizardClient.submitRequest(req, res, verifyRequestCallback, next, true);
+}
+
+function bankWizardCompanyRequest(req, res, next) {
+    bankwizardClient.submitRequest(req, res, verifyRequestCallback, next, false);
+}
+
+module.exports = Object.freeze({
+    bankWizardPersonalRequest,
+    bankWizardCompanyRequest,
+});

--- a/bankwizard/bankwizard-service.test.js
+++ b/bankwizard/bankwizard-service.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const personalRequest = require('../testing/personalRequest');
+const companyRequest = require('../testing/companyRequest');
+const mockVerifyResponse = require('../testing/verifyResponse');
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+describe('BankWizard service tests', () => {
+    jest.mock('../services/soap/bankwizard-client', () => ({
+        submitRequest: jest.fn((req, res, cb, next, personal) => {
+            const response = mockVerifyResponse(req, personal);
+            cb(response, res, undefined, next);
+        }),
+        // eslint-disable-next-line no-unused-vars
+        getBranchData: jest.fn((client, verifyResult, responseBody, cb, res, next) => {
+            responseBody.branchName = 'Test branch';
+            responseBody.bankName = 'Test bank';
+            cb(responseBody, res, verifyResult, next);
+        }),
+    }));
+
+    // eslint-disable-next-line global-require
+    const bankWizardService = require('./bankwizard-service');
+
+    it('should validate valid accounts', () => {
+        const res = {
+            status: (code) => ({
+                json: (msg) => {
+                    expect(code).toEqual(200);
+                    expect(msg.validateScore).toEqual(true);
+                },
+            }),
+        };
+        bankWizardService.bankWizardPersonalRequest(personalRequest, res, (err) => {
+            throw err;
+        });
+    });
+
+    it('should extract scores for personal requests', () => {
+        const res = {
+            status: (code) => ({
+                json: (msg) => {
+                    expect(code).toEqual(200);
+                    expect(msg.personalScore).toEqual(1);
+                    expect(msg.addressScore).toEqual(2);
+                },
+            }),
+        };
+        bankWizardService.bankWizardPersonalRequest(personalRequest, res, (err) => {
+            throw err;
+        });
+    });
+
+    it('should extract scores for company requests', () => {
+        const res = {
+            status: (code) => ({
+                json: (msg) => {
+                    expect(code).toEqual(200);
+                    expect(msg.companyScore).toEqual(1);
+                },
+            }),
+        };
+        bankWizardService.bankWizardCompanyRequest(companyRequest, res, (err) => {
+            throw err;
+        });
+    });
+
+    it('should include branch data', () => {
+        const res = {
+            status: (code) => ({
+                json: (msg) => {
+                    expect(code).toEqual(200);
+                    expect(msg.bankName).toEqual('Test bank');
+                    expect(msg.branchName).toEqual('Test branch');
+                },
+            }),
+        };
+        bankWizardService.bankWizardPersonalRequest(personalRequest, res, (err) => {
+            throw err;
+        });
+    });
+});

--- a/bankwizard/routes.js
+++ b/bankwizard/routes.js
@@ -2,15 +2,13 @@
 
 const express = require('express');
 
-const createBankWizardService = require('./bankwizard-service');
+const bankWizardService = require('./bankwizard-service');
 
 const router = express.Router();
 
 router.route('/personal').post((req, res, next) => {
     try {
-        const bankWizardService = createBankWizardService();
-        const answer = bankWizardService.bankWizardPersonalRequest(req.body);
-        res.status(200).json(answer);
+        bankWizardService.bankWizardPersonalRequest(req.body, res, next);
     } catch (err) {
         next(err);
     }
@@ -18,9 +16,7 @@ router.route('/personal').post((req, res, next) => {
 
 router.route('/company').post((req, res, next) => {
     try {
-        const bankWizardService = createBankWizardService();
-        const answer = bankWizardService.bankWizardCompanyRequest(req.body);
-        res.status(200).json(answer);
+        bankWizardService.bankWizardCompanyRequest(req.body, res, next);
     } catch (err) {
         next(err);
     }

--- a/bankwizard/routes.js
+++ b/bankwizard/routes.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const express = require('express');
+
+const createBankWizardService = require('./bankwizard-service');
+
+const router = express.Router();
+
+router.route('/personal').post((req, res, next) => {
+    try {
+        const bankWizardService = createBankWizardService();
+        const answer = bankWizardService.bankWizardPersonalRequest(req.body);
+        res.status(200).json(answer);
+    } catch (err) {
+        next(err);
+    }
+});
+
+router.route('/company').post((req, res, next) => {
+    try {
+        const bankWizardService = createBankWizardService();
+        const answer = bankWizardService.bankWizardCompanyRequest(req.body);
+        res.status(200).json(answer);
+    } catch (err) {
+        next(err);
+    }
+});
+
+router.route('/status').get((req, res, next) => {
+    try {
+        res.status(200).json({status: 'Service up'});
+    } catch (err) {
+        next(err);
+    }
+});
+
+module.exports = router;

--- a/bankwizard/routes.test.js
+++ b/bankwizard/routes.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const request = require('supertest');
+const app = require('../app');
+
+const personalRequest = {
+    firstName: 'John',
+    lastName: 'Doe',
+    dOB: '2000-01-01',
+    sortCode: '01-01-01',
+    accountNumber: '12345678',
+    rollNumber: '',
+    houseNumber: '1',
+    street: 'Real Road',
+    postCode: 'AA1 1AA',
+};
+
+const companyRequest = {
+    companyName: 'Test Ltd.',
+    sortCode: '01-01-01',
+    accountNumber: '12345678',
+    rollNumber: '',
+    houseNumber: '1',
+    street: 'Real Road',
+    postCode: 'AA1 1AA',
+};
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+describe('REST endpoint tests', () => {
+    jest.doMock('./bankwizard-service.js', () => {
+        const bankwizardServiceMock = {
+            bankWizardPersonalRequest: jest.fn(() => true),
+            bankWizardCompanyRequest: jest.fn(() => false),
+        };
+        return () => bankwizardServiceMock;
+    });
+
+    describe('POST /v2/bankwizard/personal', () => {
+        it('should return status 200 and give a normal response when the request is valid', async () => {
+            const response = await request(app)
+                .post('/v2/bankwizard/personal')
+                .send(personalRequest);
+            expect(response.status).toEqual(200);
+            expect(response.body).toEqual(true);
+        });
+
+        it('should return status 400 when the request is malformed', async () => {
+            const response = await request(app)
+                .post('/v2/bankwizard/personal')
+                .send(companyRequest);
+            expect(response.status).toEqual(400);
+        });
+    });
+
+    describe('POST /v2/bankwizard/company', () => {
+        it('should return status 200 and give a normal response when the request is valid', async () => {
+            const response = await request(app).post('/v2/bankwizard/company').send(companyRequest);
+            expect(response.status).toEqual(200);
+            expect(response.body).toEqual(false);
+        });
+
+        it('should return status 400 when the request is malformed', async () => {
+            const response = await request(app)
+                .post('/v2/bankwizard/company')
+                .send(personalRequest);
+            expect(response.status).toEqual(400);
+        });
+    });
+
+    describe('GET /v2/bankwizard/status', () => {
+        it('should return status 200', async () => {
+            const response = await request(app).get('/v2/bankwizard/status').send();
+            expect(response.status).toEqual(200);
+        });
+    });
+});

--- a/bankwizard/routes.test.js
+++ b/bankwizard/routes.test.js
@@ -1,42 +1,28 @@
 'use strict';
 
 const request = require('supertest');
-const app = require('../app');
 
-const personalRequest = {
-    firstName: 'John',
-    lastName: 'Doe',
-    dOB: '2000-01-01',
-    sortCode: '01-01-01',
-    accountNumber: '12345678',
-    rollNumber: '',
-    houseNumber: '1',
-    street: 'Real Road',
-    postCode: 'AA1 1AA',
-};
-
-const companyRequest = {
-    companyName: 'Test Ltd.',
-    sortCode: '01-01-01',
-    accountNumber: '12345678',
-    rollNumber: '',
-    houseNumber: '1',
-    street: 'Real Road',
-    postCode: 'AA1 1AA',
-};
+const personalRequest = require('../testing/personalRequest');
+const companyRequest = require('../testing/companyRequest');
 
 beforeEach(() => {
     jest.resetModules();
 });
 
 describe('REST endpoint tests', () => {
-    jest.doMock('./bankwizard-service.js', () => {
-        const bankwizardServiceMock = {
-            bankWizardPersonalRequest: jest.fn(() => true),
-            bankWizardCompanyRequest: jest.fn(() => false),
-        };
-        return () => bankwizardServiceMock;
-    });
+    jest.mock('./bankwizard-service', () => ({
+        // eslint-disable-next-line no-unused-vars
+        bankWizardPersonalRequest: jest.fn((req, res, next) => {
+            res.status(200).json('test');
+        }),
+        // eslint-disable-next-line no-unused-vars
+        bankWizardCompanyRequest: jest.fn((req, res, next) => {
+            res.status(200).json('test');
+        }),
+    }));
+
+    // eslint-disable-next-line global-require
+    const app = require('../app');
 
     describe('POST /v2/bankwizard/personal', () => {
         it('should return status 200 and give a normal response when the request is valid', async () => {
@@ -44,7 +30,6 @@ describe('REST endpoint tests', () => {
                 .post('/v2/bankwizard/personal')
                 .send(personalRequest);
             expect(response.status).toEqual(200);
-            expect(response.body).toEqual(true);
         });
 
         it('should return status 400 when the request is malformed', async () => {
@@ -59,7 +44,6 @@ describe('REST endpoint tests', () => {
         it('should return status 200 and give a normal response when the request is valid', async () => {
             const response = await request(app).post('/v2/bankwizard/company').send(companyRequest);
             expect(response.status).toEqual(200);
-            expect(response.body).toEqual(false);
         });
 
         it('should return status 400 when the request is malformed', async () => {

--- a/openapi/src/json-schemas/api/bankwizard/company/post/req/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/company/post/req/200.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "companyName",
+        "sortCode",
+        "accountNumber",
+        "houseNumber",
+        "street",
+        "postCode"
+    ],
+    "properties": {
+        "companyName": {
+            "$ref": "../../../../../models/definitions/non-empty-string.json"
+        },
+        "sortCode": {
+            "$ref": "../../../../../models/definitions/sort-code.json"
+        },
+        "accountNumber": {
+            "$ref": "../../../../../models/definitions/account-number.json"
+        },
+        "rollNumber": {
+            "type": "string"
+        },
+        "houseNumber": {
+            "type": "string"
+        },
+        "street": {
+            "type": "string"
+        },
+        "postCode": {
+            "$ref": "../../../../../models/definitions/post-code.json"
+        }
+    }
+}

--- a/openapi/src/json-schemas/api/bankwizard/company/post/res/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/company/post/res/200.json
@@ -1,10 +1,19 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Personal request response",
-    "required": ["data"],
+    "title": "Company request response",
+    "required": ["validateScore", "branchName", "bankName", "companyScore"],
     "properties": {
-        "data": {
-            "type": "boolean"
+        "validateScore": {
+            "$ref": "../../../../../models/definitions/digit.json"
+        },
+        "branchName": {
+            "type": "string"
+        },
+        "bankName": {
+            "type": "string"
+        },
+        "companyScore": {
+            "$ref": "../../../../../models/definitions/digit.json"
         }
     }
 }

--- a/openapi/src/json-schemas/api/bankwizard/company/post/res/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/company/post/res/200.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Personal request response",
+    "required": ["data"],
+    "properties": {
+        "data": {
+            "type": "boolean"
+        }
+    }
+}

--- a/openapi/src/json-schemas/api/bankwizard/personal/post/req/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/personal/post/req/200.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "firstName",
+        "lastName",
+        "dOB",
+        "sortCode",
+        "accountNumber",
+        "houseNumber",
+        "street",
+        "postCode"
+    ],
+    "properties": {
+        "firstName": {
+            "$ref": "../../../../../models/definitions/non-empty-string.json"
+        },
+        "lastName": {
+            "$ref": "../../../../../models/definitions/non-empty-string.json"
+        },
+        "dOB": {
+            "$ref": "../../../../../models/definitions/date-of-birth.json"
+        },
+        "sortCode": {
+            "$ref": "../../../../../models/definitions/sort-code.json"
+        },
+        "accountNumber": {
+            "$ref": "../../../../../models/definitions/account-number.json"
+        },
+        "rollNumber": {
+            "type": "string"
+        },
+        "houseNumber": {
+            "type": "string"
+        },
+        "street": {
+            "type": "string"
+        },
+        "postCode": {
+            "$ref": "../../../../../models/definitions/post-code.json"
+        }
+    }
+}

--- a/openapi/src/json-schemas/api/bankwizard/personal/post/res/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/personal/post/res/200.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Personal request response",
+    "required": ["data"],
+    "properties": {
+        "data": {
+            "type": "boolean"
+        }
+    }
+}

--- a/openapi/src/json-schemas/api/bankwizard/personal/post/res/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/personal/post/res/200.json
@@ -1,10 +1,22 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Personal request response",
-    "required": ["data"],
+    "required": ["validateScore", "branchName", "bankName", "personalScore", "addressScore"],
     "properties": {
-        "data": {
-            "type": "boolean"
+        "validateScore": {
+            "$ref": "../../../../../models/definitions/digit.json"
+        },
+        "branchName": {
+            "type": "string"
+        },
+        "bankName": {
+            "type": "string"
+        },
+        "personalScore": {
+            "$ref": "../../../../../models/definitions/digit.json"
+        },
+        "addressScore": {
+            "$ref": "../../../../../models/definitions/digit.json"
         }
     }
 }

--- a/openapi/src/json-schemas/api/bankwizard/status/get/res/200.json
+++ b/openapi/src/json-schemas/api/bankwizard/status/get/res/200.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Personal request response",
+    "required": ["status"],
+    "properties": {
+        "status": {
+            "type": "string"
+        }
+    }
+}

--- a/openapi/src/json-schemas/models/definitions/account-number.json
+++ b/openapi/src/json-schemas/models/definitions/account-number.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "account-number",
+    "type": "string",
+    "pattern": "^[0-9]{7,8}$"
+}

--- a/openapi/src/json-schemas/models/definitions/date-of-birth.json
+++ b/openapi/src/json-schemas/models/definitions/date-of-birth.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "date-of-birth",
+    "type": "string",
+    "format": "date"
+}

--- a/openapi/src/json-schemas/models/definitions/digit.json
+++ b/openapi/src/json-schemas/models/definitions/digit.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "digit",
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 9
+}
+

--- a/openapi/src/json-schemas/models/definitions/non-empty-string.json
+++ b/openapi/src/json-schemas/models/definitions/non-empty-string.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "non-empty-string",
+    "type": "string",
+    "pattern": "^(?!\\s*$).+"
+}
+

--- a/openapi/src/json-schemas/models/definitions/post-code.json
+++ b/openapi/src/json-schemas/models/definitions/post-code.json
@@ -2,6 +2,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "post-code",
     "type": "string",
-    "pattern": "^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\\s?[0-9][A-Za-z]{2})$"
+    "pattern": "^([A-Z]{1,2}\\d[A-Z\\d]? ?\\d[A-Z]{2}|GIR ?0A{2})$"
 }
 

--- a/openapi/src/json-schemas/models/definitions/post-code.json
+++ b/openapi/src/json-schemas/models/definitions/post-code.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "post-code",
+    "type": "string",
+    "pattern": "^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\\s?[0-9][A-Za-z]{2})$"
+}
+

--- a/openapi/src/json-schemas/models/definitions/sort-code.json
+++ b/openapi/src/json-schemas/models/definitions/sort-code.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "sort-code",
+    "type": "string",
+    "pattern": "^[0-9]{2}-[0-9]{2}-[0-9]{2}$"
+}

--- a/openapi/src/openapi-src.json
+++ b/openapi/src/openapi-src.json
@@ -1,32 +1,156 @@
 {
     "openapi": "3.0.2",
     "info": {
-        "title": "Your API name",
-        "description": "Your API description",
-        "version": "0.0.0",
+        "title": "CICA Experian BankWizard Integration Service",
+        "description": "Handle BankWizard requests",
+        "version": "0.0.1",
         "license": {
             "name": "MIT"
         },
         "contact": {
             "name": "API Support",
-            "email": "your-support-email@11ce303a-bd9d-41c9-8019-2946598c7a07.gov.uk"
+            "email": "api@cica.gov.uk"
         }
     },
     "servers": [
         {
-            "url": "/api/v1"
+            "url": "/v2/bankwizard"
         }
     ],
-    "tags": [{"name": "Foos"}, {"name": "ProgressEntries"}],
+    "tags": [
+        {
+            "name": "BankWizard"
+        }
+    ],
     "paths": {
-    
+        "/personal": {
+            "post": {
+                "tags": [
+                    "BankWizard"
+                ],
+                "summary": "Submit a personal type request",
+                "description": "Submit a personal type request to the Experian BankWizard service",
+                "operationId": "personal",
+                "requestBody": {
+                    "description": "Personal request template",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "./json-schemas/api/bankwizard/personal/post/req/200.json"
+                            },
+                            "example": {
+                                "firstName": "John",
+                                "lastName": "Doe",
+                                "dOB": "01/01/2000",
+                                "sortCode": "01-01-01",
+                                "accountNumber": "12345678",
+                                "rollNumber": "",
+                                "houseNumber": "1",
+                                "street": "Real Road",
+                                "postCode": "AA1 1AA"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "./json-schemas/api/bankwizard/personal/post/res/200.json"
+                                },
+                                "example": {
+                                    "data": "true"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    }
+                }
+            }
+        },
+        "/company": {
+            "post": {
+                "tags": [
+                    "BankWizard"
+                ],
+                "summary": "Submit a company type request",
+                "description": "Submit a company type request to the Experian BankWizard service",
+                "operationId": "company",
+                "requestBody": {
+                    "description": "Company request template",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "./json-schemas/api/bankwizard/company/post/req/200.json"
+                            },
+                            "example": {
+                                "companyName": "My Company Ltd.",
+                                "sortCode": "01-01-01",
+                                "accountNumber": "12345678",
+                                "rollNumber": "",
+                                "houseNumber": "1",
+                                "street": "Real Road",
+                                "postCode": "AA1 1AA"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "./json-schemas/api/bankwizard/company/post/res/200.json"
+                                },
+                                "example": {
+                                    "data": "true"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    }
+                }
+            }
+        },
+        "/status": {
+            "get": {
+                "tags": ["BankWizard"],
+                "summary": "Status check",
+                "description": "Returns a status 200 if the service is currently running",
+                "operationId": "status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "./json-schemas/api/bankwizard/status/get/res/200.json"
+                                },
+                                "example": {
+                                    "status": "Service up"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     },
     "components": {
         "responses": {
             "BadRequest": {
                 "description": "There is an issue with the request",
                 "content": {
-                    "application/vnd.api+json": {
+                    "application/json": {
                         "schema": {
                             "$ref": "./json-schemas/api/responses/400.json"
                         },
@@ -45,7 +169,7 @@
             "UnauthorizedError": {
                 "description": "Access token is missing or invalid",
                 "content": {
-                    "application/vnd.api+json": {
+                    "application/json": {
                         "schema": {
                             "$ref": "./json-schemas/api/responses/401.json"
                         },
@@ -63,7 +187,7 @@
             "Forbidden": {
                 "description": "The JWT doesn't permit access to this endpoint",
                 "content": {
-                    "application/vnd.api+json": {
+                    "application/json": {
                         "schema": {
                             "$ref": "./json-schemas/api/responses/403.json"
                         },
@@ -82,7 +206,7 @@
             "NotFound": {
                 "description": "The specified resource was not found",
                 "content": {
-                    "application/vnd.api+json": {
+                    "application/json": {
                         "schema": {
                             "$ref": "./json-schemas/api/responses/404.json"
                         },
@@ -101,7 +225,7 @@
             "Conflict": {
                 "description": "Conflict",
                 "content": {
-                    "application/vnd.api+json": {
+                    "application/json": {
                         "schema": {
                             "$ref": "./json-schemas/api/responses/409.json"
                         },

--- a/openapi/src/openapi-src.json
+++ b/openapi/src/openapi-src.json
@@ -62,7 +62,11 @@
                                     "$ref": "./json-schemas/api/bankwizard/personal/post/res/200.json"
                                 },
                                 "example": {
-                                    "data": "true"
+                                    "validateScore": true,
+                                    "branchName": "Test branch",
+                                    "bankName": "Test institution",
+                                    "personalScore": 1,
+                                    "addressScore": 2
                                 }
                             }
                         }
@@ -110,7 +114,10 @@
                                     "$ref": "./json-schemas/api/bankwizard/company/post/res/200.json"
                                 },
                                 "example": {
-                                    "data": "true"
+                                    "validateScore": true,
+                                    "branchName": "Test branch",
+                                    "bankName": "Test institution",
+                                    "companyScore": 1
                                 }
                             }
                         }
@@ -123,7 +130,9 @@
         },
         "/status": {
             "get": {
-                "tags": ["BankWizard"],
+                "tags": [
+                    "BankWizard"
+                ],
                 "summary": "Status check",
                 "description": "Returns a status 200 if the service is currently running",
                 "operationId": "status",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "nodemon": "^3.1.7",
                 "prettier": "^3.3.3",
                 "speccy": "github:wework/speccy#740d19d88935db7735250c16abc2ad09256b5854",
+                "supertest": "^7.0.0",
                 "yamljs": "^0.3.0"
             },
             "engines": {
@@ -2857,6 +2858,16 @@
                 "node": ">=18"
             }
         },
+        "node_modules/component-emitter": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+            "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2949,6 +2960,13 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+            "license": "MIT"
+        },
+        "node_modules/cookiejar": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+            "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/core-js": {
@@ -9848,6 +9866,54 @@
             "peer": true,
             "peerDependencies": {
                 "stylis": "^3.5.0"
+            }
+        },
+        "node_modules/superagent": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+            "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "component-emitter": "^1.3.0",
+                "cookiejar": "^2.1.4",
+                "debug": "^4.3.4",
+                "fast-safe-stringify": "^2.1.1",
+                "form-data": "^4.0.0",
+                "formidable": "^3.5.1",
+                "methods": "^1.1.2",
+                "mime": "2.6.0",
+                "qs": "^6.11.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/superagent/node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/supertest": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+            "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "methods": "^1.1.2",
+                "superagent": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.18.0"
             }
         },
         "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run:dev",
+        "start:stub": "npm run start:dev & npm run stub",
         "openapi:build": "speccy lint openapi/src/openapi-src.json -j && speccy resolve ./openapi/src/openapi-src.json -j | yaml2json --pretty --indentation 4 --save - > ./openapi/openapi.json && node ./openapi/src/dereference-openapi.js",
         "build:run:dev": "npm run openapi:build && node --inspect=0.0.0.0:9229 ./bin/www",
         "prepare": "npm run openapi:build",
         "pretest": "npm run openapi:build",
         "test": "jest",
         "coverage": "jest --coverage",
+        "stub": "node ./stubs/bankwizard-stub.js",
         "dump-eslint-conf": "eslint --print-config ./app.js > ./stuff/eslint-conf.json",
         "lint": "eslint .",
         "lint:fix": "eslint --fix ."

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
         "speccy": "github:wework/speccy#740d19d88935db7735250c16abc2ad09256b5854",
+        "supertest": "^7.0.0",
         "yamljs": "^0.3.0"
     },
     "license": "MIT"

--- a/services/soap/bankwizard-client.js
+++ b/services/soap/bankwizard-client.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const soap = require('soap');
+
+const wsdl = './BankWizardService-v1.wsdl';
+
+const url = process.env.BANKWIZARD_URL;
+
+function buildPersonalDetails(req) {
+    return {
+        firstName: req.firstName,
+        surname: req.lastName,
+        dob: req.dOB,
+    };
+}
+
+function buildAddress(req) {
+    const deliveryPoint = [];
+    const postalPoint = [];
+
+    if (req.houseNumber && !req.houseNumber !== '') {
+        deliveryPoint.push({
+            deliveryType: 'houseNumber',
+            value: req.houseNumber,
+        });
+    }
+
+    if (req.street && !req.street !== '') {
+        postalPoint.push({
+            postalType: 'street',
+            value: req.street,
+        });
+    }
+
+    postalPoint.push({
+        postalType: 'postcode',
+        value: req.postCode,
+    });
+
+    return {
+        deliveryPoint,
+        postalPoint,
+    };
+}
+
+function buildAccount(req) {
+    const account = {
+        sortCode: req.sortCode,
+        accountNumber: req.accountNumber,
+        checkContext: 'Direct Credit',
+    };
+    if (req.rollNumber && req.rollNumber !== '') {
+        account.rollNumber = req.rollNumber;
+    }
+    return account;
+}
+
+function buildVerifyRequest(req, personal) {
+    const msg = {
+        accountInformation: buildAccount(req),
+    };
+
+    if (personal) {
+        msg.personalInformation = {
+            personal: buildPersonalDetails(req),
+            address: buildAddress(req),
+            ownerType: null,
+        };
+    } else {
+        msg.companyInformation = {
+            companyName: req.companyName,
+            address: buildAddress(req),
+        };
+    }
+    return msg;
+}
+
+function getBranchData(client, verifyResult, responseBody, cb, res, next) {
+    const branchRequest = {
+        dataAccessKey: verifyResult.accountInformation.dataAccessKey,
+        returnSubBranches: false,
+        language: 'en',
+    };
+    client.BankWizard_v1_1_Service.BankWizard_v1_1_0_Port.GetBranchData(
+        branchRequest,
+        (error, result) => {
+            if (error) {
+                next(error);
+            } else if (result.branchData.length > 0) {
+                const branch = result.branchData[0];
+                responseBody.branchName = branch.branchName;
+                responseBody.bankName = branch.institutionName;
+                cb(responseBody, res, verifyResult, next);
+            } else {
+                // TODO error handle no branch data
+            }
+        },
+    );
+}
+
+function submitRequest(req, res, cb, next, personal) {
+    soap.createClient(
+        wsdl,
+        (err, client) => {
+            if (err) {
+                next(err);
+            } else {
+                client.BankWizard_v1_1_Service.BankWizard_v1_1_0_Port.Verify(
+                    buildVerifyRequest(req, personal),
+                    (error, result) => {
+                        if (error) {
+                            next(error);
+                        } else {
+                            cb(result, res, client, next);
+                        }
+                    },
+                );
+            }
+        },
+        url,
+    );
+}
+
+module.exports = Object.freeze({submitRequest, getBranchData});

--- a/services/soap/bankwizard-client.test.js
+++ b/services/soap/bankwizard-client.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+const personalRequest = require('../../testing/personalRequest');
+const companyRequest = require('../../testing/companyRequest');
+const verifyResponse = require('../../testing/verifyResponse');
+
+const bankwizardClient = require('./bankwizard-client');
+
+const accountInformation = {
+    sortCode: '01-01-01',
+    accountNumber: '12345678',
+    checkContext: 'Direct Credit',
+    rollNumber: '1A',
+};
+
+const address = {
+    deliveryPoint: [
+        {
+            deliveryType: 'houseNumber',
+            value: '1',
+        },
+    ],
+    postalPoint: [
+        {
+            postalType: 'street',
+            value: 'Real Road',
+        },
+        {
+            postalType: 'postcode',
+            value: 'AA1 1AA',
+        },
+    ],
+};
+
+const personalInformation = {
+    personal: {
+        firstName: 'John',
+        surname: 'Doe',
+        dob: '2000-01-01',
+    },
+    address,
+    ownerType: null,
+};
+
+const companyInformation = {
+    companyName: 'Test Ltd.',
+    address,
+};
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+describe('BankWizard Client', () => {
+    jest.mock('soap');
+
+    describe('getBranchData()', () => {
+        it('should carry over the access key', () => {
+            const client = {
+                BankWizard_v1_1_Service: {
+                    BankWizard_v1_1_0_Port: {
+                        // eslint-disable-next-line no-unused-vars
+                        GetBranchData: (msg, cb) => {
+                            expect(msg.dataAccessKey).toEqual('test-accesskey');
+                        },
+                    },
+                },
+            };
+
+            bankwizardClient.getBranchData(
+                client,
+                verifyResponse(personalRequest, true),
+                {},
+                () => {},
+                {},
+                () => {},
+            );
+        });
+
+        it('should format the bank data', () => {
+            const client = {
+                BankWizard_v1_1_Service: {
+                    BankWizard_v1_1_0_Port: {
+                        // eslint-disable-next-line no-unused-vars
+                        GetBranchData: (msg, cb) => {
+                            const res = {
+                                branchData: [
+                                    {
+                                        institutionName: 'Test institution',
+                                        branchName: 'Test branch',
+                                        address: {
+                                            addressLine: [],
+                                            postOrZipCode: 'AA1 1AA',
+                                        },
+                                        telephoneNumber: '07123456789',
+                                        faxNumber: '123-456-7890',
+                                        closureDate: '2000-01-01',
+                                    },
+                                ],
+                            };
+                            cb(null, res);
+                        },
+                    },
+                },
+            };
+
+            bankwizardClient.getBranchData(
+                client,
+                verifyResponse(personalRequest, true),
+                {},
+                // eslint-disable-next-line no-unused-vars
+                (responseBody, res, verifyResult, next) => {
+                    expect(responseBody.branchName).toEqual('Test branch');
+                    expect(responseBody.bankName).toEqual('Test institution');
+                },
+                null,
+                (err) => {
+                    throw err;
+                },
+            );
+        });
+    });
+
+    describe('submitRequest()', () => {
+        it('should correctly format account information from a request', () => {
+            const res = {
+                status: (code) => ({
+                    json: (msg) => {
+                        expect(code).toEqual(200);
+                        expect(msg.accountInformation).toEqual(accountInformation);
+                    },
+                }),
+            };
+
+            bankwizardClient.submitRequest(personalRequest, res, () => {}, true);
+        });
+
+        it('should correctly format personal information from a request', () => {
+            const res = {
+                status: (code) => ({
+                    json: (msg) => {
+                        expect(code).toEqual(200);
+                        expect(msg.personalInformation).toEqual(personalInformation);
+                    },
+                }),
+            };
+
+            bankwizardClient.submitRequest(personalRequest, res, () => {}, true);
+        });
+
+        it('should correctly format company information from a request', () => {
+            const res = {
+                status: (code) => ({
+                    json: (msg) => {
+                        expect(code).toEqual(200);
+                        expect(msg.companyInformation).toEqual(companyInformation);
+                    },
+                }),
+            };
+
+            bankwizardClient.submitRequest(companyRequest, res, () => {}, false);
+        });
+
+        it('should not include company information in a personal request', () => {
+            const res = {
+                status: (code) => ({
+                    json: (msg) => {
+                        expect(code).toEqual(200);
+                        expect(msg.companyInformation).toBeUndefined();
+                    },
+                }),
+            };
+
+            bankwizardClient.submitRequest(companyRequest, res, () => {}, true);
+        });
+
+        it('should not include personal information in a company request', () => {
+            const res = {
+                status: (code) => ({
+                    json: (msg) => {
+                        expect(code).toEqual(200);
+                        expect(msg.personalInformation).toBeUndefined();
+                    },
+                }),
+            };
+
+            bankwizardClient.submitRequest(personalRequest, res, () => {}, false);
+        });
+    });
+});

--- a/stubs/bankwizard-stub.js
+++ b/stubs/bankwizard-stub.js
@@ -1,0 +1,83 @@
+/* eslint-disable no-unused-vars */
+
+'use strict';
+
+const soap = require('soap');
+const fs = require('fs');
+const http = require('http');
+
+const wsdl = fs.readFileSync('./BankWizardService-v1.wsdl', 'utf8');
+
+const server = http.createServer((req, res) => {
+    res.end(`404 Not Found: ${req.url}`);
+});
+
+server.listen(8000);
+
+function GetBranchData(args, cb, headers, req) {
+    return {
+        branchData: [
+            {
+                institutionName: 'Test institution',
+                branchName: 'Test branch',
+                address: {
+                    addressLine: [],
+                    postOrZipCode: 'AA1 1AA',
+                },
+                telephoneNumber: '07123456789',
+                faxNumber: '123-456-7890',
+                closureDate: '2000-01-01',
+            },
+        ],
+    };
+}
+
+function Verify(args, cb, headers, req) {
+    const res = {
+        accountInformation: {
+            sortCode: args.accountInformation.sortCode,
+            accountNumber: args.accountInformation.accountNumber,
+            rollNumber: args.accountInformation.rollNumber,
+            dataAccessKey: 'stub-accesskey',
+            accountVerificationStatus: 'Match',
+        },
+        conditions: [],
+    };
+    if (args.personalInformation) {
+        res.personalInformation = {
+            personalDetailsScore: 1,
+            addressScore: 2,
+            accountSetupDateMatch: 'Match',
+            accountSetupDateScore: 3,
+            accountTypeMatch: 'Match',
+            accountOwnerMatch: 'Match',
+        };
+    } else {
+        res.companyInformation = {
+            companyNameScore: 1,
+            companyNameAndAddressScore: 2,
+            companyTypeMatch: 'Match',
+            registrationNumberMatch: 'Match',
+            proprietorDetailsScore: 3,
+            companyAccountSetupDateScore: 4,
+        };
+    }
+    return res;
+}
+
+const service = {
+    BankWizard_v1_1_Service: {
+        BankWizard_v1_1_0_Port: {
+            GetBranchData,
+            Verify,
+        },
+    },
+};
+
+soap.listen(server, '/wsdl', service, wsdl, (err, res) => {
+    if (err) {
+        console.log(err.message);
+    } else {
+        console.log('Stub soap server started');
+    }
+});

--- a/testing/companyRequest.js
+++ b/testing/companyRequest.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+    companyName: 'Test Ltd.',
+    sortCode: '01-01-01',
+    accountNumber: '12345678',
+    rollNumber: '1A',
+    houseNumber: '1',
+    street: 'Real Road',
+    postCode: 'AA1 1AA',
+};

--- a/testing/personalRequest.js
+++ b/testing/personalRequest.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+    firstName: 'John',
+    lastName: 'Doe',
+    dOB: '2000-01-01',
+    sortCode: '01-01-01',
+    accountNumber: '12345678',
+    rollNumber: '1A',
+    houseNumber: '1',
+    street: 'Real Road',
+    postCode: 'AA1 1AA',
+};

--- a/testing/verifyResponse.js
+++ b/testing/verifyResponse.js
@@ -1,0 +1,36 @@
+'use strict';
+
+function response(req, personal) {
+    const res = {
+        accountInformation: {
+            sortCode: req.sortCode,
+            accountNumber: req.accountNumber,
+            rollNumber: req.rollNumber,
+            dataAccessKey: 'test-accesskey',
+            accountVerificationStatus: 'Match',
+        },
+        conditions: [],
+    };
+    if (personal) {
+        res.personalInformation = {
+            personalDetailsScore: 1,
+            addressScore: 2,
+            accountSetupDateMatch: 'Match',
+            accountSetupDateScore: 3,
+            accountTypeMatch: 'Match',
+            accountOwnerMatch: 'Match',
+        };
+    } else {
+        res.companyInformation = {
+            companyNameScore: 1,
+            companyNameAndAddressScore: 2,
+            companyTypeMatch: 'Match',
+            registrationNumberMatch: 'Match',
+            proprietorDetailsScore: 3,
+            companyAccountSetupDateScore: 4,
+        };
+    }
+    return res;
+}
+
+module.exports = response;


### PR DESCRIPTION
Please only review after https://github.com/ministryofjustice/cica-experian-bank-wizard/pull/1 has been merged.

Includes SOAP API client for Bank Wizard, stub Bank Wizard service, updated OpenAPI documentation and the path for data transfer between the REST endpoints and the SOAP client. Note that error handling will be included in a separate PR and for now only the ideal path is accounted for.